### PR TITLE
Ty rewrite

### DIFF
--- a/src/codegen_fox32.rs
+++ b/src/codegen_fox32.rs
@@ -266,7 +266,7 @@ pub fn gen_program(ir: &Program) -> String {
     code
 }
 
-pub fn gen_function(f: &Function, function_name: &str, get_size: SizeFinder) -> String {
+fn gen_function(f: &Function, function_name: &str, get_size: SizeFinder) -> String {
     let mut code = String::new();
     let RegAllocInfo {
         regs,

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -94,6 +94,19 @@ impl TyMap {
                 }
                 string
             }
+	    TyKind::Struct(fields) => {
+                let mut string = "struct(".to_owned();
+                for (i, (name, ty)) in fields.iter().enumerate() {
+                    if i != 0 {
+                        string.push_str(", ");
+                    }
+		    string.push_str(name);
+		    string.push_str(": ");
+                    string.push_str(&self.format(*ty));
+                }
+		string.push(')');
+		string
+	    }
         }
     }
 }
@@ -406,7 +419,8 @@ impl Function {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Ty(u128);
+// I'd prefer not to have this field public but it's needed for `ir_display`.
+pub struct Ty(pub(crate) u128);
 
 /// The type of any value operated on.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -9,23 +9,27 @@ pub struct Program {
     pub functions: Map<Str, Function>,
     /// The type signature of every function including extern functions.
     pub function_tys: Map<Str, (Vec<Ty>, Vec<Ty>)>,
+    /// All the types used in this program, indexed by `Ty`s.
     pub tys: TyMap,
 }
 
+/// The storage for all the types used in a program.
 #[derive(Clone, Debug, Default)]
 pub struct TyMap {
+    /// The storage structure mapping type indexes to type data.
     pub(crate) inner: Map<Ty, TyKind>,
+    /// A counter for the next type index to return.
     next_ty: u128,
 }
 
 impl TyMap {
     /// Construct a new [`TyMap`]
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Self::default()
     }
 
     /// Get a type immutably.
-    pub fn get(&self, index: Ty) -> Option<&TyKind> {
+    #[must_use] pub fn get(&self, index: Ty) -> Option<&TyKind> {
         self.inner.get(&index)
     }
 
@@ -57,12 +61,12 @@ impl TyMap {
     }
 
     /// Format a type as a string through its id.
-    pub fn format(&self, index: Ty) -> String {
+    #[must_use] pub fn format(&self, index: Ty) -> String {
         self.format_kind(&self[index])
     }
 
     /// Format a type as a string.
-    pub fn format_kind(&self, kind: &TyKind) -> String {
+    #[must_use] pub fn format_kind(&self, kind: &TyKind) -> String {
         // yeah this is bad
         match kind {
             TyKind::Int(size) => size.to_string(),
@@ -419,6 +423,7 @@ impl Function {
     }
 }
 
+/// An index into the program level type storage.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 // I'd prefer not to have this field public but it's needed for `ir_display`.
 pub struct Ty(pub(crate) u128);

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -75,6 +75,7 @@ impl TyMap {
                     }
                     string.push_str(&self.format(param));
                 }
+                string.push(')');
                 match returns.len() {
                     0 => {}
                     1 => {
@@ -94,19 +95,19 @@ impl TyMap {
                 }
                 string
             }
-	    TyKind::Struct(fields) => {
+            TyKind::Struct(fields) => {
                 let mut string = "struct(".to_owned();
                 for (i, (name, ty)) in fields.iter().enumerate() {
                     if i != 0 {
                         string.push_str(", ");
                     }
-		    string.push_str(name);
-		    string.push_str(": ");
+                    string.push_str(name);
+                    string.push_str(": ");
                     string.push_str(&self.format(*ty));
                 }
-		string.push(')');
-		string
-	    }
+                string.push(')');
+                string
+            }
         }
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -14,7 +14,7 @@ pub struct Program {
 
 #[derive(Clone, Debug, Default)]
 pub struct TyMap {
-    inner: Map<Ty, TyKind>,
+    pub(crate) inner: Map<Ty, TyKind>,
     next_ty: u128,
 }
 

--- a/src/ir_builder.rs
+++ b/src/ir_builder.rs
@@ -29,7 +29,7 @@ pub enum ErrorKind {
     DoesNotYield(Span),
     CantAssignToConstant,
     UnknownIntLiteralSuffix,
-    CantCastToTy(Ty),
+    CantCastToTy(String),
     #[allow(dead_code)]
     Todo(&'static str),
 }
@@ -37,7 +37,7 @@ pub enum ErrorKind {
 type Error = Spanned<ErrorKind>;
 type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct IrBuilder<'a> {
     parameters: Vec<Register>,
     current_block: Vec<Inst>,
@@ -48,8 +48,10 @@ struct IrBuilder<'a> {
     spans: Map<Register, Span>,
     scopes: Vec<Map<Str, Register>>,
     next_reg_id: u128,
+    program_tys: &'a mut TyMap,
     function_tys: &'a Map<Str, (Vec<Ty>, Option<Ty>)>,
     defined_tys: &'a DefinedTys,
+    dummy_ty: Ty,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -66,34 +68,41 @@ struct DefinedTys {
 }
 
 impl DefinedTys {
-    fn build_ty(&self, ty: &ast::Ty) -> Result<Ty> {
+    fn build_ty(&self, ty: &ast::Ty, program_tys: &mut TyMap) -> Result<Ty> {
         use ast::TyKind as T;
         match &ty.kind {
             T::Name(name) => match self.tys.get(&name.kind) {
-                Some((ty, _)) => Ok(ty.clone()),
+                Some(&(ty, _)) => Ok(ty),
                 None => Err(Error {
                     kind: ErrorKind::NotFound("type", name.kind.clone()),
                     span: ty.span.clone(),
                 }),
             },
-            T::Pointer(inner) => self.build_ty(inner).map(Box::new).map(Ty::Pointer),
+            T::Pointer(inner) => {
+                let inner_kind = self.build_ty(inner, program_tys)?;
+                Ok(program_tys.insert(TyKind::Pointer(inner_kind)))
+            }
             T::Function(params, returns) => {
                 let params = params
                     .iter()
-                    .map(|t| self.build_ty(t))
+                    .map(|t| self.build_ty(t, program_tys))
                     .collect::<Result<_>>()?;
                 let returns = returns
                     .iter()
-                    .map(|t| self.build_ty(t))
+                    .map(|t| self.build_ty(t, program_tys))
                     .collect::<Result<_>>()?;
-                Ok(Ty::Function(params, returns))
+                Ok(program_tys.insert(TyKind::Function(params, returns)))
             }
         }
     }
 }
 
 impl<'a> IrBuilder<'a> {
-    fn new(function_tys: &'a Map<Str, (Vec<Ty>, Option<Ty>)>, defined_tys: &'a DefinedTys) -> Self {
+    fn new(
+        function_tys: &'a Map<Str, (Vec<Ty>, Option<Ty>)>,
+        defined_tys: &'a DefinedTys,
+        program_tys: &'a mut TyMap,
+    ) -> Self {
         Self {
             parameters: vec![],
             current_block: vec![],
@@ -104,8 +113,10 @@ impl<'a> IrBuilder<'a> {
             spans: Map::new(),
             scopes: vec![Map::new()],
             next_reg_id: 0,
+            dummy_ty: program_tys.insert(TyKind::Int(IntKind::U8)),
             function_tys,
             defined_tys,
+            program_tys,
         }
     }
 
@@ -286,11 +297,11 @@ impl<'a> IrBuilder<'a> {
             E::As(value, ty) => {
                 let value_reg = self.build_expr_unvoid(value, span.clone())?;
                 let ir_ty = self.build_ty(ty)?;
-                let kind = match ir_ty {
-                    Ty::Int(k) => k,
-                    t => {
+                let kind = match self.program_tys[ir_ty] {
+                    TyKind::Int(k) => k,
+                    ref t => {
                         return Err(Error {
-                            kind: ErrorKind::CantCastToTy(t),
+                            kind: ErrorKind::CantCastToTy(self.program_tys.format_kind(t)),
                             // Should we annotate the span of the type or the entire `as` expression?
                             span: ty.span.clone(),
                         });
@@ -371,8 +382,8 @@ impl<'a> IrBuilder<'a> {
             }
             E::Call(callee, args) => {
                 let callee = self.build_expr_unvoid(callee, span.clone())?;
-                let returns: Vec<_> = match self.tys.get(&callee).unwrap() {
-                    Ty::Function(_, returns) => {
+                let returns: Vec<_> = match &self.program_tys[self.tys[&callee]] {
+                    TyKind::Function(_, returns) => {
                         assert!(matches!(returns.len(), 0 | 1));
                         // somewhat silly clone because we need mutable access to `self` for `new_reg`.
                         returns
@@ -381,9 +392,9 @@ impl<'a> IrBuilder<'a> {
                             .map(|ty| self.new_reg(ty, span.clone()))
                             .collect()
                     }
-                    Ty::Int(_) | Ty::Pointer(_) | Ty::Struct(_) => {
+                    _ => {
                         // dummy return
-                        vec![self.new_reg(Ty::Int(IntKind::Usize), span.clone())]
+                        vec![self.new_reg(self.dummy_ty, span.clone())]
                     }
                 };
                 let return_reg = returns.first().copied();
@@ -444,8 +455,8 @@ impl<'a> IrBuilder<'a> {
         self.scopes.pop();
     }
 
-    fn build_ty(&self, ty: &ast::Ty) -> Result<Ty> {
-        self.defined_tys.build_ty(ty)
+    fn build_ty(&mut self, ty: &ast::Ty) -> Result<Ty> {
+        self.defined_tys.build_ty(ty, &mut self.program_tys)
     }
 
     fn new_var(&mut self, name: Name, ty: Ty) -> Register {
@@ -471,36 +482,35 @@ impl<'a> IrBuilder<'a> {
         self.push_inst(Inst::Store(reg, sk));
         reg
     }
-    pub fn guess_ty(&self, sk: &StoreKind) -> Ty {
-        const DUMMY_TY: Ty = Ty::Int(IntKind::U8);
+    pub fn guess_ty(&mut self, sk: &StoreKind) -> Ty {
         use StoreKind as Sk;
-        let t = |r| self.tys.get(r).unwrap().clone();
+        let dummy_ty = self.dummy_ty;
+        let t = |r| *self.tys.get(r).unwrap();
         match sk {
-            &Sk::Int(_, kind) | &Sk::IntCast(_, kind) => Ty::Int(kind),
+            &Sk::Int(_, kind) | &Sk::IntCast(_, kind) => self.program_tys.insert(TyKind::Int(kind)),
             Sk::Phi(regs) => t(regs.first_key_value().expect("empty phi").1),
             Sk::BinOp(_, lhs, _rhs) => t(lhs),
             Sk::PtrOffset(ptr, _) => t(ptr),
             Sk::FieldOffset(r, field) => {
-                let Ty::Pointer(value) = t(r) else {
-                    println!("foo");
-                    return DUMMY_TY;
+                let TyKind::Pointer(value) = self.program_tys[t(r)] else {
+                    return dummy_ty;
                 };
-                let Ty::Struct(fields) = value.as_ref() else {
-                    println!("foofoo");
-                    return DUMMY_TY;
+                let TyKind::Struct(fields) = &self.program_tys[value] else {
+                    return dummy_ty;
                 };
                 fields
-                    .iter()
+                    .clone()
+                    .into_iter()
                     .find_map(|(name, ty)| {
-                        (name == field).then(|| Ty::Pointer(Box::new(ty.clone())))
+                        (&name == field).then(|| self.program_tys.insert(TyKind::Pointer(ty)))
                     })
-                    .unwrap_or(DUMMY_TY)
+                    .unwrap_or(dummy_ty)
             }
-            Sk::StackAlloc(ty) => Ty::Pointer(Box::new(ty.clone())),
+            &Sk::StackAlloc(ty) => self.program_tys.insert(TyKind::Pointer(ty)),
             Sk::Copy(r) | Sk::UnaryOp(UnaryOp::Neg, r) => t(r),
-            Sk::Read(r) => match self.tys.get(r).unwrap() {
-                Ty::Pointer(inner) => inner.as_ref().clone(),
-                Ty::Int(_) | Ty::Function(..) | Ty::Struct(_) => DUMMY_TY,
+            Sk::Read(r) => match self.program_tys[self.tys[r]] {
+                TyKind::Pointer(inner) => inner,
+                _ => dummy_ty,
             },
             Sk::Function(name) => {
                 let (args, returns) = self
@@ -508,7 +518,8 @@ impl<'a> IrBuilder<'a> {
                     .get(name)
                     .expect("constructed function instruction to unknown function")
                     .clone();
-                Ty::Function(args, returns.into_iter().collect())
+                self.program_tys
+                    .insert(TyKind::Function(args, returns.into_iter().collect()))
             }
         }
     }
@@ -547,15 +558,38 @@ impl<'a> IrBuilder<'a> {
 
 pub fn build(program: &ast::Program) -> Result<Program> {
     use ast::DeclKind as D;
-    let mut function_tys = Map::new();
+    let mut program_tys = TyMap::new();
+    // Global type construction first pass: register all type names in `defined_tys`. Type declarations can reference structs declared after themselves, even cyclically.
     let mut defined_tys = DefinedTys {
         tys: Map::from([
-            ("u8".into(), (Ty::Int(IntKind::U8), None)),
-            ("usize".into(), (Ty::Int(IntKind::Usize), None)),
+            (
+                "u8".into(),
+                (program_tys.insert(TyKind::Int(IntKind::U8)), None),
+            ),
+            (
+                "usize".into(),
+                (program_tys.insert(TyKind::Int(IntKind::Usize)), None),
+            ),
         ]),
     };
-    // collect struct types
-    // currently we only accept forward declarations of structs (bad). fixing this in the general case requires a pervasive rewrite of the IR type system.
+    for ast::Decl { kind, span: _ } in &program.decls {
+        match kind {
+            D::Function(_) | D::ExternFunction(_) => {}
+            D::Struct(ast::Struct { name, fields: _ }) => {
+                let maybe_clash = defined_tys.tys.insert(
+                    name.kind.clone(),
+                    (program_tys.reserve(), name.span.clone().some()),
+                );
+                if let Some((_, previous_span)) = maybe_clash {
+                    return Err(Error {
+                        kind: ErrorKind::NameConflict("type", previous_span),
+                        span: name.span.clone(),
+                    });
+                }
+            }
+        }
+    }
+    // Global type construction second pass: fill out actual type information we skipped in the first pass.
     for ast::Decl { kind, span: _ } in &program.decls {
         match kind {
             D::Function(_) | D::ExternFunction(_) => {}
@@ -563,7 +597,7 @@ pub fn build(program: &ast::Program) -> Result<Program> {
                 let mut ir_fields: Vec<(Str, Ty)> = Vec::with_capacity(fields.len());
                 let mut names = Map::new();
                 for (field_name, field_ty) in fields {
-                    let ty = defined_tys.build_ty(field_ty)?;
+                    let ty = defined_tys.build_ty(field_ty, &mut program_tys)?;
                     ir_fields.push((field_name.kind.clone(), ty));
                     if let Some(previous_span) =
                         names.insert(field_name.kind.clone(), field_name.span.clone())
@@ -574,22 +608,15 @@ pub fn build(program: &ast::Program) -> Result<Program> {
                         });
                     }
                 }
-                let ty = Ty::Struct(ir_fields);
-                let name_span = name.span.clone();
-                // check if another ty in the same scope has the same name
-                let maybe_clash = defined_tys
-                    .tys
-                    .insert(name.kind.clone(), (ty, name_span.some()));
-                if let Some((_, previous_span)) = maybe_clash {
-                    return Err(Error {
-                        kind: ErrorKind::NameConflict("type", previous_span),
-                        span: name.span.clone(),
-                    });
-                }
+                let kind = TyKind::Struct(ir_fields);
+                let ty_index = defined_tys.tys[&name.kind].0;
+                program_tys.insert_at(ty_index, kind);
             }
         }
     }
+    let mut function_tys = Map::new();
     for ast::Decl { kind, span: _ } in &program.decls {
+        let mut build_ty = |t| defined_tys.build_ty(t, &mut program_tys);
         match kind {
             D::Function(ast::Function {
                 name,
@@ -602,12 +629,9 @@ pub fn build(program: &ast::Program) -> Result<Program> {
                     (
                         parameters
                             .iter()
-                            .map(|arg| defined_tys.build_ty(&arg.1))
+                            .map(|(_, t)| build_ty(t))
                             .collect::<Result<_>>()?,
-                        returns
-                            .as_ref()
-                            .map(|ret| defined_tys.build_ty(ret))
-                            .transpose()?,
+                        returns.as_ref().map(build_ty).transpose()?,
                     ),
                 );
             }
@@ -621,23 +645,21 @@ pub fn build(program: &ast::Program) -> Result<Program> {
                     (
                         parameters
                             .iter()
-                            .map(|arg| defined_tys.build_ty(arg))
+                            .map(&mut build_ty)
                             .collect::<Result<_>>()?,
-                        returns
-                            .as_ref()
-                            .map(|ret| defined_tys.build_ty(ret))
-                            .transpose()?,
+                        returns.as_ref().map(build_ty).transpose()?,
                     ),
                 );
             }
             D::Struct(_) => {}
         }
     }
+    let function_tys = function_tys;
     let mut functions = Map::new();
     for decl in &program.decls {
         match &decl.kind {
             D::Function(fn_decl) => {
-                let builder = IrBuilder::new(&function_tys, &defined_tys);
+                let builder = IrBuilder::new(&function_tys, &defined_tys, &mut program_tys);
                 let function = builder.build_function(fn_decl)?;
                 functions.insert(fn_decl.name.kind.clone(), function);
             }
@@ -651,5 +673,6 @@ pub fn build(program: &ast::Program) -> Result<Program> {
     Ok(Program {
         functions,
         function_tys,
+        tys: program_tys,
     })
 }

--- a/src/ir_desugar.rs
+++ b/src/ir_desugar.rs
@@ -50,6 +50,14 @@ pub fn desugar_program(program: &mut Program) {
         desugar_function(f, tys);
     }
     // TODO: update `function_tys` and the function `tys`
+    // For each `Vec<Ty>` (params and returns), we need to expand any struct `Ty` into a list of its fields.
+    // 1. for each ty in the ty map
+    // 2. if it's a function, mem::take its params and returns
+    // pass it to desugar_ty_vec (which no longer has to be recursive) maybe call it desugar_struct_in_function_signature
+
+    // dsifs:
+    // 1. for each ty
+    // 2. if struct, expand to fields and retape
 }
 
 pub fn desugar_function(f: &mut Function, ty_map: &mut TyMap) {

--- a/src/ir_desugar.rs
+++ b/src/ir_desugar.rs
@@ -7,31 +7,36 @@ use crate::ir::*;
 
 type StructFields = Map<Register, (Ty, Vec<Str>)>;
 
-fn make_struct_fields(fields: &[(Str, Ty)], next_register: &mut u128) -> StructFields {
+fn make_struct_fields(
+    fields: &[(Str, Ty)],
+    next_register: &mut u128,
+    ty_map: &TyMap,
+) -> StructFields {
     fn visit(
         this: &mut StructFields,
         prefix: &[Str],
         fields: &[(Str, Ty)],
         next_register: &mut u128,
+        ty_map: &TyMap,
     ) {
         for (field, ty) in fields {
             let mut path = prefix.to_vec();
             path.push(field.clone());
-            match ty {
+            match &ty_map[*ty] {
                 // Types that don't need desugaring
-                Ty::Int(_) | Ty::Pointer(_) | Ty::Function { .. } => {
+                TyKind::Int(_) | TyKind::Pointer(_) | TyKind::Function { .. } => {
                     let r = Register(*next_register);
                     *next_register += 1;
                     this.insert(r, (ty.clone(), path));
                 }
-                Ty::Struct(child_fields) => {
-                    visit(this, &path, child_fields, next_register);
+                TyKind::Struct(child_fields) => {
+                    visit(this, &path, child_fields, next_register, ty_map);
                 }
             }
         }
     }
     let mut this = StructFields::new();
-    visit(&mut this, &[], fields, next_register);
+    visit(&mut this, &[], fields, next_register, ty_map);
     this
 }
 
@@ -39,23 +44,26 @@ pub fn desugar_program(program: &mut Program) {
     let Program {
         functions,
         function_tys,
+        tys,
     } = program;
     for f in functions.values_mut() {
-        desugar_function(f);
+        desugar_function(f, tys);
     }
     for (params, returns) in function_tys.values_mut() {
-        desugar_ty_vec(params);
-        desugar_ty_vec(returns);
+        desugar_ty_vec(params, tys);
+        desugar_ty_vec(returns, tys);
     }
 }
 
-pub fn desugar_function(f: &mut Function) {
+pub fn desugar_function(f: &mut Function, ty_map: &mut TyMap) {
     let struct_regs: Map<Register, StructFields> = f
         .tys
         .iter()
-        .filter_map(|(&r, ty)| match ty {
-            Ty::Struct(fields) => Some((r, make_struct_fields(fields, &mut f.next_register))),
-            Ty::Int(_) | Ty::Pointer(_) | Ty::Function { .. } => None,
+        .filter_map(|(&r, &ty)| match &ty_map[ty] {
+            TyKind::Struct(fields) => {
+                Some((r, make_struct_fields(fields, &mut f.next_register, ty_map)))
+            }
+            TyKind::Int(_) | TyKind::Pointer(_) | TyKind::Function { .. } => None,
         })
         .collect();
     for (r, fields) in &struct_regs {
@@ -75,7 +83,7 @@ pub fn desugar_function(f: &mut Function) {
 
     desugar_vec(&struct_regs, parameters);
     for block in blocks.values_mut() {
-        desugar_block(&struct_regs, block, tys, next_register);
+        desugar_block(&struct_regs, block, tys, next_register, ty_map);
     }
     for (r, fields) in &struct_regs {
         // NOTE: `desugar_block` relies on getting the type of `r`
@@ -87,7 +95,7 @@ pub fn desugar_function(f: &mut Function) {
         }
     }
     for ty in tys.values_mut() {
-        desugar_ty(ty);
+        desugar_ty(ty, ty_map);
     }
 }
 
@@ -96,6 +104,7 @@ fn desugar_block(
     block: &mut Block,
     tys: &mut Map<Register, Ty>,
     next_register: &mut u128,
+    ty_map: &mut TyMap,
 ) {
     let Block {
         insts,
@@ -148,20 +157,21 @@ fn desugar_block(
                 insts.remove(i);
                 for (&r, (_, accesses)) in fields {
                     let mut ptr = dst;
-                    let mut ty = tys[&src].clone();
+                    let mut ty = tys[&src];
                     for access in accesses {
                         ty = {
-                            let Ty::Struct(fields) = ty else {
+                            let TyKind::Struct(fields) = &ty_map[ty] else {
                                 unreachable!();
                             };
                             fields
-                                .into_iter()
-                                .find_map(|(name, ty)| (&name == access).then_some(ty))
+                                .iter()
+                                .find_map(|(name, ty)| (name == access).then_some(*ty))
                                 .unwrap()
                         };
                         let new_ptr = Register(*next_register);
                         *next_register += 1;
-                        tys.insert(new_ptr, Ty::Pointer(Box::new(ty.clone())));
+                        let ty = ty_map.insert(TyKind::Pointer(ty));
+                        tys.insert(new_ptr, ty);
                         insts.insert(
                             i,
                             Inst::Store(new_ptr, Sk::FieldOffset(ptr, access.clone())),
@@ -176,7 +186,7 @@ fn desugar_block(
             &mut Inst::Store(r, ref mut sk) => {
                 if let Sk::StackAlloc(ty) = sk {
                     eprintln!("before: {ty}");
-                    desugar_ty(ty);
+                    desugar_ty(ty, ty_map);
                     eprintln!("after:  {ty}");
                 }
                 let Some(fields) = struct_regs.get(&r) else {
@@ -235,20 +245,21 @@ fn desugar_block(
                         insts.remove(i);
                         for (&r2, (_, accesses)) in fields {
                             let mut ptr = src;
-                            let mut ty = tys[&r].clone();
+                            let mut ty = tys[&r];
                             for access in accesses {
                                 ty = {
-                                    let Ty::Struct(fields) = ty else {
+                                    let TyKind::Struct(fields) = &ty_map[ty] else {
                                         unreachable!();
                                     };
                                     fields
-                                        .into_iter()
-                                        .find_map(|(name, ty)| (&name == access).then_some(ty))
+                                        .iter()
+                                        .find_map(|(name, ty)| (name == access).then_some(*ty))
                                         .unwrap()
                                 };
                                 let new_ptr = Register(*next_register);
                                 *next_register += 1;
-                                tys.insert(new_ptr, Ty::Pointer(Box::new(ty.clone())));
+                                let ty = ty_map.insert(TyKind::Pointer(ty));
+                                tys.insert(new_ptr, ty);
                                 insts.insert(
                                     i,
                                     Inst::Store(new_ptr, Sk::FieldOffset(ptr, access.clone())),
@@ -266,23 +277,23 @@ fn desugar_block(
     }
 }
 
-fn desugar_ty(ty: &mut Ty) {
-    match ty {
+fn desugar_ty(ty: Ty, ty_map: &mut TyMap) {
+    match &ty_map[ty] {
         Ty::Int(_) => {}
-        Ty::Pointer(ty) => desugar_ty(ty),
+        &Ty::Pointer(ty) => desugar_ty(ty, ty_map),
         Ty::Function(params, returns) => {
             desugar_ty_vec(params);
             desugar_ty_vec(returns);
         }
         Ty::Struct(fields) => {
-            for (_, ty) in fields {
-                desugar_ty(ty);
+            for &(_, ty) in fields {
+                desugar_ty(ty, ty_map);
             }
         }
     }
 }
 
-fn desugar_ty_vec(tys: &mut Vec<Ty>) {
+fn desugar_ty_vec(tys: &mut Vec<Ty>, ty_map: &TyMap) {
     let mut i = 0;
     while let Some(ty) = tys.get_mut(i) {
         i += 1;

--- a/src/ir_display.rs
+++ b/src/ir_display.rs
@@ -126,7 +126,7 @@ impl DisplayWithName for Exit {
 
 impl DisplayWithName for Function {
     fn fmt_with_name<'a>(&'a self, f: F, name: &str) -> Result {
-        let reg_def = |r: &'a Register| WithTy(r, self.tys.get(r).unwrap_or(&Ty::Int(IntKind::U8)));
+        let reg_def = |r: &'a Register| WithTy(r, self.tys.get(r).unwrap());
         write!(
             f,
             "fn {name}({})",
@@ -224,6 +224,12 @@ impl Display for Program {
 }
 
 impl Display for Ty {
+    fn fmt(&self, f: F) -> Result {
+        write!(f, "ty_{}", self.0)
+    }
+}
+
+impl Display for TyKind {
     fn fmt(&self, f: F) -> Result {
         match self {
             Self::Int(kind) => write!(f, "{kind}"),

--- a/src/ir_opt.rs
+++ b/src/ir_opt.rs
@@ -209,19 +209,19 @@ fn constant_propagation_impl(f: &mut Function) {
                 let val = match op {
                     UnaryOp::Neg => x.wrapping_neg(),
                 };
-		(val, kind)
+                (val, kind)
             }
             StoreKind::BinOp(op, lhs, rhs) => {
                 let (lhs, lhs_kind) = *const_list.get(&lhs)?;
                 let (rhs, rhs_kind) = *const_list.get(&rhs)?;
-		assert_eq!(lhs_kind, rhs_kind);
+                assert_eq!(lhs_kind, rhs_kind);
                 let val = match op {
                     BinOp::Add => lhs.wrapping_add(rhs),
                     BinOp::Sub => lhs.wrapping_sub(rhs),
                     BinOp::Mul => lhs.wrapping_mul(rhs),
                     BinOp::CmpLe => i128::from(lhs <= rhs),
                 };
-		(val, lhs_kind)
+                (val, lhs_kind)
             }
             _ => return None,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,12 +55,12 @@ enum ErrorMode {
 }
 
 fn typecheck(ir: &ir::Program, src: &str, file_path: &str, error_mode: ErrorMode) -> bool {
-    match typechecker::typecheck(&ir) {
+    match typechecker::typecheck(ir) {
         Ok(()) => false,
         Err((fn_name, e)) => {
             use typechecker::ErrorKind as E;
             let fun = ir.functions.get(&fn_name).unwrap();
-            let snippet = Snippet::source(&src).origin(file_path).fold(true);
+            let snippet = Snippet::source(src).origin(file_path).fold(true);
             let t = |r: ir::Register| ir.tys.format(fun.tys[&r]);
             let (title, snippet): (String, _) = match e {
                 E::NotInt(reg) => (
@@ -203,14 +203,14 @@ fn main() -> ExitCode {
         }
     };
     eprintln!("#IR:\n{ir}\n");
-    if typecheck(&ir, &src, &file_path, ErrorMode::User) {
+    if typecheck(&ir, &src, file_path, ErrorMode::User) {
         return ExitCode::FAILURE;
     }
 
     eprintln!("#Desugaring phase");
     ir_desugar::desugar_program(&mut ir);
     eprintln!("{ir}\n");
-    if typecheck(&ir, &src, &file_path, ErrorMode::Internal) {
+    if typecheck(&ir, &src, file_path, ErrorMode::Internal) {
         return ExitCode::FAILURE;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,35 +157,30 @@ fn main() -> ExitCode {
             use typechecker::ErrorKind as E;
             let fun = ir.functions.get(&fn_name).unwrap();
             let snippet = Snippet::source(&src).origin(file_path).fold(true);
+            let t = |r: ir::Register| &ir.tys[fun.tys[&r]];
             let (title, snippet): (String, _) = match e {
                 E::NotInt(reg) => (
-                    format!("expected integer, got {}", fun.tys.get(&reg).unwrap()),
+                    format!("expected integer, got {}", t(reg)),
                     snippet.annotation(Level::Error.span(fun.spans.get(&reg).unwrap().clone())),
                 ),
                 E::NotPointer(reg) => (
-                    format!(
-                        "cannot dereference a value of type {}",
-                        fun.tys.get(&reg).unwrap()
-                    ),
+                    format!("cannot dereference a value of type {}", t(reg),),
                     snippet.annotation(Level::Error.span(fun.spans.get(&reg).unwrap().clone())),
                 ),
                 E::NotFunction(reg) => (
-                    format!("expected function, got {}", fun.tys.get(&reg).unwrap()),
+                    format!("expected function, got {}", t(reg),),
                     snippet.annotation(Level::Error.span(fun.spans.get(&reg).unwrap().clone())),
                 ),
                 E::NotStruct(reg) => (
-                    format!(
-                        "type {} does not support field access",
-                        fun.tys.get(&reg).unwrap()
-                    ),
+                    format!("type {} does not support field access", t(reg),),
                     snippet.annotation(Level::Error.span(fun.spans.get(&reg).unwrap().clone())),
                 ),
                 E::NoFieldNamed(reg, field) => (
-                    format!("{} does not have field {field}", fun.tys.get(&reg).unwrap()),
+                    format!("{} does not have field {field}", t(reg),),
                     snippet.annotation(Level::Error.span(fun.spans.get(&reg).unwrap().clone())),
                 ),
                 E::Expected(reg, given_ty) => (
-                    format!("expected {given_ty}, got {}", fun.tys.get(&reg).unwrap()),
+                    format!("expected {given_ty}, got {}", t(reg)),
                     snippet.annotation(Level::Error.span(fun.spans.get(&reg).unwrap().clone())),
                 ),
             };

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -101,7 +101,7 @@ impl<'a> TypeChecker<'a> {
                 };
                 fields
                     .iter()
-                    .find_map(|(name, ty)| (name == field).then(|| TyKind::Pointer(*ty)))
+                    .find_map(|(name, ty)| (name == field).then_some(TyKind::Pointer(*ty)))
                     .ok_or_else(|| (self.name.into(), ErrorKind::NoFieldNamed(r, field.clone())))?
             }
             Sk::UnaryOp(UnaryOp::Neg, rhs) => {


### PR DESCRIPTION
This rewrite changes everywhere the IR stored types to instead use indices into a type storage. This allows cyclic references between types.